### PR TITLE
Update: Drop X-XSS-Protection

### DIFF
--- a/lib/MiddlewareModule.js
+++ b/lib/MiddlewareModule.js
@@ -34,6 +34,7 @@ class MiddlewareModule extends AbstractModule {
     const { loadRouteConfig, registerRoutes } = await import('adapt-authoring-server')
     const helmetFunc = helmet({
       xFrameOptions: false,
+      xXssProtection: false,
       contentSecurityPolicy: false
     })
     // add custom middleware


### PR DESCRIPTION
### Update
- Pass `xXssProtection: false` to helmet so the deprecated `X-XSS-Protection` header is no longer emitted at all.
- Previously helmet defaulted to emitting `X-XSS-Protection: 0`, which is behaviourally modern (tells browsers not to use the legacy auditor) but still sends a deprecated header — the pen-test finding in cgkineo/adapt-authoring#87 flagged this.

### Testing
- `curl -I http://localhost:5678/` and `curl -I http://localhost:5678/api/config` confirm the `X-XSS-Protection` header is absent on both.
- Other helmet headers (HSTS, X-Content-Type-Options, Referrer-Policy, COOP, CORP) unchanged.