### PR TITLE
New: per-MIME-category upload size limits

### DIFF
--- a/lib/MiddlewareModule.js
+++ b/lib/MiddlewareModule.js
@@ -191,7 +191,12 @@ class MiddlewareModule extends AbstractModule {
         } catch (e) {
           if (e.code !== 'EEXIST') return next(e)
         }
-        formidable(options).parse(req, async (error, fields, files) => {
+        // formidable aborts early at maxFileSize, so cap parsing at the largest per-type limit
+        const byType = options.maxFileSizeByType
+        const parseMaxFileSize = byType
+          ? Math.max(options.maxFileSize, ...Object.values(byType).map(v => typeof v === 'number' ? v : bytes(v)))
+          : options.maxFileSize
+        formidable({ ...options, maxFileSize: parseMaxFileSize }).parse(req, async (error, fields, files) => {
           if (error) {
             if (error.code === 1009) {
               const [maxSize, size] = error.message.match(/(\d+) bytes/g).map(s => bytes(Number(s.replace(' bytes', ''))))

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -5,7 +5,8 @@
  * Options which can be passed to file upload middleware
  * @memberof middleware
  * @typedef {Object} FileUploadOptions
- * @property {number} maxFileSize Maximum file size allowed by upload
+ * @property {number} maxFileSize Maximum file size allowed by upload (the global fallback)
+ * @property {Object} maxFileSizeByType Optional per-MIME-category size overrides, keyed by top-level category (e.g. `image`, `video`); values are byte counts or `bytes`-parsable strings. Categories without an entry use `maxFileSize`
  * @property {string} uploadDir Directory file upload should be stored
  * @property {Boolean} promisify If true, middleware will return a promise rather than use the standard callback. Useful when calling middleware outside of an Express middleware stack
  * @property {Boolean} removeZipSource To be used in conjunction with the unzip option. Whether the original zip file should be removed after unzipping (true by default)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,1 +1,2 @@
+export { default as resolveFileSizeLimit } from './utils/resolveFileSizeLimit.js'
 export { validateUploadedFiles } from './utils/validateUploadedFiles.js'

--- a/lib/utils/resolveFileSizeLimit.js
+++ b/lib/utils/resolveFileSizeLimit.js
@@ -1,0 +1,16 @@
+import bytes from 'bytes'
+
+/**
+ * Resolves the upload size limit (bytes) for a file from its MIME category,
+ * falling back to `options.maxFileSize`.
+ * @param {string} mimetype The file's validated MIME type
+ * @param {FileUploadOptions} options Upload options (`maxFileSize`, optional `maxFileSizeByType`)
+ * @returns {number} The size limit in bytes
+ * @memberof middleware
+ */
+export default function resolveFileSizeLimit (mimetype, options = {}) {
+  const toBytes = v => (typeof v === 'number' ? v : bytes(v))
+  const category = typeof mimetype === 'string' ? mimetype.split('/')[0] : undefined
+  const override = (options.maxFileSizeByType && category) ? options.maxFileSizeByType[category] : undefined
+  return toBytes(override ?? options.maxFileSize)
+}

--- a/lib/utils/validateUploadedFiles.js
+++ b/lib/utils/validateUploadedFiles.js
@@ -2,6 +2,7 @@ import { App } from 'adapt-authoring-core'
 import bytes from 'bytes'
 import { fileTypeFromFile } from 'file-type'
 import path from 'path'
+import resolveFileSizeLimit from './resolveFileSizeLimit.js'
 
 /**
  * Validates uploaded files against expected types and size limits
@@ -25,8 +26,9 @@ export async function validateUploadedFiles (req, filesObj, options) {
         assetErrors.push(errors.UNEXPECTED_FILE_TYPES.setData({ expectedFileTypes: options.expectedFileTypes, invalidFiles: [f.originalFilename], mimetypes: [f.mimetype] }))
       }
     }
-    if (f.size > options.maxFileSize) {
-      assetErrors.push(errors.FILE_EXCEEDS_MAX_SIZE.setData({ size: bytes(f.size), maxSize: bytes(options.maxFileSize) }))
+    const maxSize = resolveFileSizeLimit(f.mimetype, options)
+    if (f.size > maxSize) {
+      assetErrors.push(errors.FILE_EXCEEDS_MAX_SIZE.setData({ size: bytes(f.size), maxSize: bytes(maxSize) }))
     }
   }))
   if (assetErrors.length) {

--- a/tests/utils-resolveFileSizeLimit.spec.js
+++ b/tests/utils-resolveFileSizeLimit.spec.js
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import bytes from 'bytes'
+import resolveFileSizeLimit from '../lib/utils/resolveFileSizeLimit.js'
+
+describe('resolveFileSizeLimit()', () => {
+  const options = {
+    maxFileSize: bytes('50mb'),
+    maxFileSizeByType: { image: '10mb', video: '250mb', font: bytes('2mb') }
+  }
+  const cases = [
+    ['image/png matches the image override', 'image/png', options, bytes('10mb')],
+    ['video/mp4 matches the video override', 'video/mp4', options, bytes('250mb')],
+    ['font value already in bytes is passed through', 'font/woff2', options, bytes('2mb')],
+    ['uncategorised type falls back to maxFileSize', 'application/pdf', options, bytes('50mb')],
+    ['unknown mimetype falls back to maxFileSize', undefined, options, bytes('50mb')],
+    ['no byType map uses maxFileSize', 'image/png', { maxFileSize: bytes('50mb') }, bytes('50mb')]
+  ]
+  for (const [name, mimetype, opts, expected] of cases) {
+    it(name, () => {
+      assert.equal(resolveFileSizeLimit(mimetype, opts), expected)
+    })
+  }
+})


### PR DESCRIPTION
### New
- The file upload parsers now accept an optional `maxFileSizeByType` map (keyed by top-level MIME category, e.g. `image`/`video`/`font`) so callers can cap upload sizes per category, falling back to the global `maxFileSize` for any category without an entry. Backwards-compatible: with no map, behaviour is unchanged.
- `validateUploadedFiles` resolves the per-file limit from the validated MIME type via a new `resolveFileSizeLimit` util; the `formidable` parse cap is raised to the largest configured category so a category allowed to exceed the global isn't aborted early.

### Testing
- New `tests/utils-resolveFileSizeLimit.spec.js` (table-driven: category match, byte-string vs number values, fallback, no-map). Existing `validateUploadedFiles` tests still pass.